### PR TITLE
chore: Add Service Connect Metrics in Alarm Based Rollback

### DIFF
--- a/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
@@ -70,6 +70,22 @@ export interface DeploymentCircuitBreaker {
 }
 
 /**
+ * The ECS metric enum props
+ */
+export interface EcsMetricEnumProps {
+  /**
+   * Whether it is a service connect metric
+   * @default false
+   */
+  readonly isServiceConnectMetric?: boolean;
+  /**
+   * Whether it is not a service connect metric
+   * @default false
+   */
+  readonly isOtherServiceMetric?: boolean;
+}
+
+/**
  * The ecs metric class
  */
 export class EcsMetric {
@@ -196,8 +212,8 @@ export class EcsMetric {
   /**
    * Add custom metric
    */
-  public static custom(value: string) {
-    return new EcsMetric(value);
+  public static custom(value: string, ecsMetricProps?: EcsMetricEnumProps) {
+    return new EcsMetric(value, ecsMetricProps);
   }
 
   public constructor(
@@ -205,7 +221,16 @@ export class EcsMetric {
      * customValue refers to metric name
      */
     public readonly customValue: string,
-  ) { }
+    /**
+     * Ecs Metric props
+     */
+    public readonly ecsMetricProps?: EcsMetricEnumProps,
+  ) {
+    if (ecsMetricProps?.isServiceConnectMetric) {
+      // Update service connect metric map with custom service connect metric
+      EcsMetric.SERVICE_CONNECT_METRIC_MAP[customValue] = customValue;
+    }
+  }
 
   /**
    * Determine if it's a service connect metric

--- a/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
@@ -74,28 +74,45 @@ export interface DeploymentCircuitBreaker {
  */
 export class EcsMetric {
   /**
+   * Service Connect Metric Map
+   */
+  public static readonly SERVICE_CONNECT_METRIC_MAP: Record<string, string> = {
+    ActiveConnectionCount: 'ActiveConnectionCount',
+    NewConnectionCount: 'NewConnectionCount',
+    ProcessedBytes: 'ProcessedBytes',
+    RequestCount: 'RequestCount',
+    GrpcRequestCount: 'GrpcRequestCount',
+    HTTPCode_Target_2XX_Count: 'HTTPCode_Target_2XX_Count',
+    HTTPCode_Target_3XX_Count: 'HTTPCode_Target_3XX_Count',
+    HTTPCode_Target_4XX_Count: 'HTTPCode_Target_4XX_Count',
+    HTTPCode_Target_5XX_Count: 'HTTPCode_Target_5XX_Count',
+    RequestCountPerTarget: 'RequestCountPerTarget',
+    TargetProcessedBytes: 'TargetProcessedBytes',
+    TargetResponseTime: 'TargetResponseTime',
+  };
+  /**
    * CpuReservation Metric
-   * Units of this metric is percentages
+   * This metric is expressed in percent of total CPU reserved.
    */
   public static readonly CPU_RESERVATION = new EcsMetric('CPUReservation');
   /**
    * CpuUtilization Metric
-   * Units of this metrics is percentages
+   * This metric is expressed in percent of total CPU utlized.
    */
   public static readonly CPU_UTILIZATION = new EcsMetric('CPUUtilization');
   /**
    * MemoryReservation Metric
-   * Units of this metrics is percentages
+   * This metric is expressed in percent of total Memory reserved.
    */
   public static readonly MEMORY_RESERVATION = new EcsMetric('MemoryReservation');
   /**
    * MemoryUtilization Metric
-   * Units of this metrics is percentages
+   * This metric is expressed in percent of total Memory utilized.
    */
   public static readonly MEMORY_UTILIZATION = new EcsMetric('MemoryUtilization');
   /**
    * GPUReservation Metric
-   * Units of this metrics is percentages
+   * This metric is expressed in percent of total GPU reserved.
    */
   public static readonly GPU_RESERVATION = new EcsMetric('GPUReservation');
   /**
@@ -103,78 +120,78 @@ export class EcsMetric {
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Count
    */
-  public static readonly ACTIVE_CONNECTION_COUNT = new EcsMetric('ActiveConnectionCount');
+  public static readonly ACTIVE_CONNECTION_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.ActiveConnectionCount);
   /**
    * NewConnectionCount Metric
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Count
    */
-  public static readonly NEW_CONNECTION_COUNT = new EcsMetric('NewConnectionCount');
+  public static readonly NEW_CONNECTION_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.NewConnectionCount);
   /**
    * ProcessedBytes Metric
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Bytes
    */
-  public static readonly PROCESSED_BYTES = new EcsMetric('ProcessedBytes');
+  public static readonly PROCESSED_BYTES = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.ProcessedBytes);
   /**
    * RequestCount Metric
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Count
    */
-  public static readonly REQUEST_COUNT = new EcsMetric('RequestCount');
+  public static readonly REQUEST_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.RequestCount);
   /**
    * GrpcRequestCount Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is GRPC in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly GRPC_REQUEST_COUNT = new EcsMetric('GrpcRequestCount');
+  public static readonly GRPC_REQUEST_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.GrpcRequestCount);
   /**
    * HTTPCode_Target_2XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_2XX_COUNT = new EcsMetric('HTTPCode_Target_2XX_Count');
+  public static readonly HTTP_CODE_TARGET_2XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_2XX_Count);
   /**
    * HTTPCode_Target_3XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_3XX_COUNT = new EcsMetric('HTTPCode_Target_3XX_Count');
+  public static readonly HTTP_CODE_TARGET_3XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_3XX_Count);
   /**
    * HTTPCode_Target_4XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_4XX_COUNT = new EcsMetric('HTTPCode_Target_4XX_Count');
+  public static readonly HTTP_CODE_TARGET_4XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_4XX_Count);
   /**
    * HTTPCode_Target_5XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_5XX_COUNT = new EcsMetric('HTTPCode_Target_5XX_Count');
+  public static readonly HTTP_CODE_TARGET_5XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_5XX_Count);
   /**
    * RequestCountPerTarget Metric
    * This metric is only available if you have configured Amazon ECS Service Connect.
    * Units of this metric is Count
    */
-  public static readonly REQUEST_COUNT_PER_TARGET = new EcsMetric('RequestCountPerTarget');
+  public static readonly REQUEST_COUNT_PER_TARGET = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.RequestCountPerTarget);
   /**
    * TargetProcessedBytes Metric
    * This metric is only available if you have configured Amazon ECS Service Connect.
    * Units of this metric is Count
    */
-  public static readonly TARGET_PROCESSED_BYTES = new EcsMetric('TargetProcessedBytes');
+  public static readonly TARGET_PROCESSED_BYTES = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.TargetProcessedBytes);
   /**
    * TargetResponseTime Metric
    * This metric is only available if you have configured Amazon ECS Service Connect.
    * Units of this metric is Milliseconds
    */
-  public static readonly TARGET_RESPONSE_TIME = new EcsMetric('TargetResponseTime');
+  public static readonly TARGET_RESPONSE_TIME = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.TargetResponseTime);
 
   /**
    * Add custom metric
@@ -194,10 +211,7 @@ export class EcsMetric {
    * Determine if it's a service connect metric
    */
   public isServiceConnectMetric(): boolean {
-    return [EcsMetric.ACTIVE_CONNECTION_COUNT, EcsMetric.NEW_CONNECTION_COUNT, EcsMetric.PROCESSED_BYTES, EcsMetric.REQUEST_COUNT,
-      EcsMetric.GRPC_REQUEST_COUNT, EcsMetric.HTTP_CODE_TARGET_2XX_COUNT, EcsMetric.HTTP_CODE_TARGET_3XX_COUNT,
-      EcsMetric.HTTP_CODE_TARGET_4XX_COUNT, EcsMetric.HTTP_CODE_TARGET_5XX_COUNT, EcsMetric.REQUEST_COUNT_PER_TARGET,
-      EcsMetric.TARGET_PROCESSED_BYTES, EcsMetric.TARGET_RESPONSE_TIME].some((ecsMetric: EcsMetric) => ecsMetric.customValue === this.customValue);
+    return !!EcsMetric.SERVICE_CONNECT_METRIC_MAP[this.customValue];
   }
 }
 

--- a/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
@@ -78,34 +78,12 @@ export interface EcsMetricEnumProps {
    * @default false
    */
   readonly isServiceConnectMetric?: boolean;
-  /**
-   * Whether it is not a service connect metric
-   * @default false
-   */
-  readonly isOtherServiceMetric?: boolean;
 }
 
 /**
  * The ecs metric class
  */
 export class EcsMetric {
-  /**
-   * Service Connect Metric Map
-   */
-  public static readonly SERVICE_CONNECT_METRIC_MAP: Record<string, string> = {
-    ActiveConnectionCount: 'ActiveConnectionCount',
-    NewConnectionCount: 'NewConnectionCount',
-    ProcessedBytes: 'ProcessedBytes',
-    RequestCount: 'RequestCount',
-    GrpcRequestCount: 'GrpcRequestCount',
-    HTTPCode_Target_2XX_Count: 'HTTPCode_Target_2XX_Count',
-    HTTPCode_Target_3XX_Count: 'HTTPCode_Target_3XX_Count',
-    HTTPCode_Target_4XX_Count: 'HTTPCode_Target_4XX_Count',
-    HTTPCode_Target_5XX_Count: 'HTTPCode_Target_5XX_Count',
-    RequestCountPerTarget: 'RequestCountPerTarget',
-    TargetProcessedBytes: 'TargetProcessedBytes',
-    TargetResponseTime: 'TargetResponseTime',
-  };
   /**
    * CpuReservation Metric
    * This metric is expressed in percent of total CPU reserved.
@@ -136,85 +114,78 @@ export class EcsMetric {
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Count
    */
-  public static readonly ACTIVE_CONNECTION_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.ActiveConnectionCount);
+  public static readonly ACTIVE_CONNECTION_COUNT = new EcsMetric('ActiveConnectionCount', { isServiceConnectMetric: true });
   /**
    * NewConnectionCount Metric
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Count
    */
-  public static readonly NEW_CONNECTION_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.NewConnectionCount);
+  public static readonly NEW_CONNECTION_COUNT = new EcsMetric('NewConnectionCount', { isServiceConnectMetric: true });
   /**
    * ProcessedBytes Metric
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Bytes
    */
-  public static readonly PROCESSED_BYTES = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.ProcessedBytes);
+  public static readonly PROCESSED_BYTES = new EcsMetric('ProcessedBytes', { isServiceConnectMetric: true });
   /**
    * RequestCount Metric
    * This metric is only available if you have configured Amazon ECS Service Connect
    * Units of this metric is Count
    */
-  public static readonly REQUEST_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.RequestCount);
+  public static readonly REQUEST_COUNT = new EcsMetric('RequestCount', { isServiceConnectMetric: true });
   /**
    * GrpcRequestCount Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is GRPC in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly GRPC_REQUEST_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.GrpcRequestCount);
+  public static readonly GRPC_REQUEST_COUNT = new EcsMetric('GrpcRequestCount', { isServiceConnectMetric: true });
   /**
    * HTTPCode_Target_2XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_2XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_2XX_Count);
+  public static readonly HTTP_CODE_TARGET_2XX_COUNT = new EcsMetric('HTTPCode_Target_2XX_Count', { isServiceConnectMetric: true });
   /**
    * HTTPCode_Target_3XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_3XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_3XX_Count);
+  public static readonly HTTP_CODE_TARGET_3XX_COUNT = new EcsMetric('HTTPCode_Target_3XX_Count', { isServiceConnectMetric: true });
   /**
    * HTTPCode_Target_4XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_4XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_4XX_Count);
+  public static readonly HTTP_CODE_TARGET_4XX_COUNT = new EcsMetric('HTTPCode_Target_4XX_Count', { isServiceConnectMetric: true });
   /**
    * HTTPCode_Target_5XX_Count Metric
    * This metric is only available if you have configured Amazon ECS Service Connect and
    * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
    * Units of this metric is Count
    */
-  public static readonly HTTP_CODE_TARGET_5XX_COUNT = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.HTTPCode_Target_5XX_Count);
+  public static readonly HTTP_CODE_TARGET_5XX_COUNT = new EcsMetric('HTTPCode_Target_5XX_Count', { isServiceConnectMetric: true });
   /**
    * RequestCountPerTarget Metric
    * This metric is only available if you have configured Amazon ECS Service Connect.
    * Units of this metric is Count
    */
-  public static readonly REQUEST_COUNT_PER_TARGET = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.RequestCountPerTarget);
+  public static readonly REQUEST_COUNT_PER_TARGET = new EcsMetric('RequestCountPerTarget', { isServiceConnectMetric: true });
   /**
    * TargetProcessedBytes Metric
    * This metric is only available if you have configured Amazon ECS Service Connect.
    * Units of this metric is Count
    */
-  public static readonly TARGET_PROCESSED_BYTES = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.TargetProcessedBytes);
+  public static readonly TARGET_PROCESSED_BYTES = new EcsMetric('TargetProcessedBytes', { isServiceConnectMetric: true });
   /**
    * TargetResponseTime Metric
    * This metric is only available if you have configured Amazon ECS Service Connect.
    * Units of this metric is Milliseconds
    */
-  public static readonly TARGET_RESPONSE_TIME = new EcsMetric(EcsMetric.SERVICE_CONNECT_METRIC_MAP.TargetResponseTime);
-
-  /**
-   * Add custom metric
-   */
-  public static custom(value: string, ecsMetricProps?: EcsMetricEnumProps) {
-    return new EcsMetric(value, ecsMetricProps);
-  }
+  public static readonly TARGET_RESPONSE_TIME = new EcsMetric('TargetResponseTime', { isServiceConnectMetric: true });
 
   public constructor(
     /**
@@ -225,18 +196,13 @@ export class EcsMetric {
      * Ecs Metric props
      */
     public readonly ecsMetricProps?: EcsMetricEnumProps,
-  ) {
-    if (ecsMetricProps?.isServiceConnectMetric) {
-      // Update service connect metric map with custom service connect metric
-      EcsMetric.SERVICE_CONNECT_METRIC_MAP[customValue] = customValue;
-    }
-  }
+  ) { }
 
   /**
    * Determine if it's a service connect metric
    */
   public isServiceConnectMetric(): boolean {
-    return !!EcsMetric.SERVICE_CONNECT_METRIC_MAP[this.customValue];
+    return !!this.ecsMetricProps?.isServiceConnectMetric;
   }
 }
 

--- a/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
@@ -94,6 +94,54 @@ export enum EcsMetric {
    * GPUReservation Metric
    */
   GPU_RESERVATION = 'GPUReservation',
+  /**
+   * ActiveConnectionCount Metric
+   */
+  ACTIVE_CONNECTION_COUNT = 'ActiveConnectionCount',
+  /**
+   * NewConnectionCount Metric
+   */
+  NEW_CONNECTION_COUNT = 'NewConnectionCount',
+  /**
+   * ProcessedBytes Metric
+   */
+  PROCESSED_BYTES = 'ProcessedBytes',
+  /**
+   * RequestCount Metric
+   */
+  REQUEST_COUNT = 'RequestCount',
+  /**
+   * GrpcRequestCount Metric
+   */
+  GRPC_REQUEST_COUNT = 'GrpcRequestCount',
+  /**
+   * HTTPCode_Target_2XX_Count Metric
+   */
+  HTTP_CODE_TARGET_2XX_COUNT = 'HTTPCode_Target_2XX_Count',
+  /**
+   * HTTPCode_Target_3XX_Count Metric
+   */
+  HTTP_CODE_TARGET_3XX_COUNT = 'HTTPCode_Target_3XX_Count',
+  /**
+   * HTTPCode_Target_4XX_Count Metric
+   */
+  HTTP_CODE_TARGET_4XX_COUNT = 'HTTPCode_Target_4XX_Count',
+  /**
+   * HTTPCode_Target_5XX_Count Metric
+   */
+  HTTP_CODE_TARGET_5XX_COUNT = 'HTTPCode_Target_5XX_Count',
+  /**
+   * RequestCountPerTarget Metric
+   */
+  REQUEST_COUNT_PER_TARGET = 'RequestCountPerTarget',
+  /**
+   * TargetProcessedBytes Metric
+   */
+  TARGET_PROCESSED_BYTES = 'TargetProcessedBytes',
+  /**
+   * TargetResponseTime Metric
+   */
+  TARGET_REESPONSE_TIME = 'TargetResponseTime',
 }
 
 /**
@@ -755,7 +803,10 @@ export abstract class BaseService extends Resource
    *   `evaluationPeriods value 3`
   */
   public createEcsMetricAlarm(metric: EcsMetric, ecsMetricAlarmProps?: EcsMetricAlarmProps): cloudwatch.Alarm {
-
+    // Throw an error if service connect is not configured
+    if (isServiceConnectMetric(metric) && !this._serviceConnectConfig) {
+      throw new Error('Service connect must be enabled to set service connect metric alarms.');
+    }
     const ecsMetric = this.metric(metric, ecsMetricAlarmProps?.metricProps);
     const alarmName = Names.uniqueId(this);
     const metricAlarm = new cloudwatch.Alarm(this, alarmName,
@@ -1599,4 +1650,9 @@ function determineContainerNameAndPort(options: DetermineContainerNameAndPortOpt
   }
 
   return {};
+}
+
+function isServiceConnectMetric(metric: EcsMetric): boolean {
+  return ![EcsMetric.CPU_RESERVATION, EcsMetric.CPU_UTILIZATION, EcsMetric.MEMORY_RESERVATION,
+    EcsMetric.MEMORY_UTILIZATION, EcsMetric.GPU_RESERVATION].includes(metric);
 }

--- a/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/base/base-service.ts
@@ -70,78 +70,135 @@ export interface DeploymentCircuitBreaker {
 }
 
 /**
- * The ecs metric name
- * Units of this metrics are percentages
+ * The ecs metric class
  */
-export enum EcsMetric {
+export class EcsMetric {
   /**
    * CpuReservation Metric
+   * Units of this metric is percentages
    */
-  CPU_RESERVATION = 'CPUReservation',
+  public static readonly CPU_RESERVATION = new EcsMetric('CPUReservation');
   /**
    * CpuUtilization Metric
+   * Units of this metrics is percentages
    */
-  CPU_UTILIZATION = 'CPUUtilization',
+  public static readonly CPU_UTILIZATION = new EcsMetric('CPUUtilization');
   /**
    * MemoryReservation Metric
+   * Units of this metrics is percentages
    */
-  MEMORY_RESERVATION = 'MemoryReservation',
+  public static readonly MEMORY_RESERVATION = new EcsMetric('MemoryReservation');
   /**
    * MemoryUtilization Metric
+   * Units of this metrics is percentages
    */
-  MEMORY_UTILIZATION = 'MemoryUtilization',
+  public static readonly MEMORY_UTILIZATION = new EcsMetric('MemoryUtilization');
   /**
    * GPUReservation Metric
+   * Units of this metrics is percentages
    */
-  GPU_RESERVATION = 'GPUReservation',
+  public static readonly GPU_RESERVATION = new EcsMetric('GPUReservation');
   /**
    * ActiveConnectionCount Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect
+   * Units of this metric is Count
    */
-  ACTIVE_CONNECTION_COUNT = 'ActiveConnectionCount',
+  public static readonly ACTIVE_CONNECTION_COUNT = new EcsMetric('ActiveConnectionCount');
   /**
    * NewConnectionCount Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect
+   * Units of this metric is Count
    */
-  NEW_CONNECTION_COUNT = 'NewConnectionCount',
+  public static readonly NEW_CONNECTION_COUNT = new EcsMetric('NewConnectionCount');
   /**
    * ProcessedBytes Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect
+   * Units of this metric is Bytes
    */
-  PROCESSED_BYTES = 'ProcessedBytes',
+  public static readonly PROCESSED_BYTES = new EcsMetric('ProcessedBytes');
   /**
    * RequestCount Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect
+   * Units of this metric is Count
    */
-  REQUEST_COUNT = 'RequestCount',
+  public static readonly REQUEST_COUNT = new EcsMetric('RequestCount');
   /**
    * GrpcRequestCount Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect and
+   * the appProtocol is GRPC in the port mapping in the task definition.
+   * Units of this metric is Count
    */
-  GRPC_REQUEST_COUNT = 'GrpcRequestCount',
+  public static readonly GRPC_REQUEST_COUNT = new EcsMetric('GrpcRequestCount');
   /**
    * HTTPCode_Target_2XX_Count Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect and
+   * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
+   * Units of this metric is Count
    */
-  HTTP_CODE_TARGET_2XX_COUNT = 'HTTPCode_Target_2XX_Count',
+  public static readonly HTTP_CODE_TARGET_2XX_COUNT = new EcsMetric('HTTPCode_Target_2XX_Count');
   /**
    * HTTPCode_Target_3XX_Count Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect and
+   * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
+   * Units of this metric is Count
    */
-  HTTP_CODE_TARGET_3XX_COUNT = 'HTTPCode_Target_3XX_Count',
+  public static readonly HTTP_CODE_TARGET_3XX_COUNT = new EcsMetric('HTTPCode_Target_3XX_Count');
   /**
    * HTTPCode_Target_4XX_Count Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect and
+   * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
+   * Units of this metric is Count
    */
-  HTTP_CODE_TARGET_4XX_COUNT = 'HTTPCode_Target_4XX_Count',
+  public static readonly HTTP_CODE_TARGET_4XX_COUNT = new EcsMetric('HTTPCode_Target_4XX_Count');
   /**
    * HTTPCode_Target_5XX_Count Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect and
+   * the appProtocol is HTTP or HTTP2 in the port mapping in the task definition.
+   * Units of this metric is Count
    */
-  HTTP_CODE_TARGET_5XX_COUNT = 'HTTPCode_Target_5XX_Count',
+  public static readonly HTTP_CODE_TARGET_5XX_COUNT = new EcsMetric('HTTPCode_Target_5XX_Count');
   /**
    * RequestCountPerTarget Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect.
+   * Units of this metric is Count
    */
-  REQUEST_COUNT_PER_TARGET = 'RequestCountPerTarget',
+  public static readonly REQUEST_COUNT_PER_TARGET = new EcsMetric('RequestCountPerTarget');
   /**
    * TargetProcessedBytes Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect.
+   * Units of this metric is Count
    */
-  TARGET_PROCESSED_BYTES = 'TargetProcessedBytes',
+  public static readonly TARGET_PROCESSED_BYTES = new EcsMetric('TargetProcessedBytes');
   /**
    * TargetResponseTime Metric
+   * This metric is only available if you have configured Amazon ECS Service Connect.
+   * Units of this metric is Milliseconds
    */
-  TARGET_REESPONSE_TIME = 'TargetResponseTime',
+  public static readonly TARGET_RESPONSE_TIME = new EcsMetric('TargetResponseTime');
+
+  /**
+   * Add custom metric
+   */
+  public static custom(value: string) {
+    return new EcsMetric(value);
+  }
+
+  public constructor(
+    /**
+     * customValue refers to metric name
+     */
+    public readonly customValue: string,
+  ) { }
+
+  /**
+   * Determine if it's a service connect metric
+   */
+  public isServiceConnectMetric(): boolean {
+    return [EcsMetric.ACTIVE_CONNECTION_COUNT, EcsMetric.NEW_CONNECTION_COUNT, EcsMetric.PROCESSED_BYTES, EcsMetric.REQUEST_COUNT,
+      EcsMetric.GRPC_REQUEST_COUNT, EcsMetric.HTTP_CODE_TARGET_2XX_COUNT, EcsMetric.HTTP_CODE_TARGET_3XX_COUNT,
+      EcsMetric.HTTP_CODE_TARGET_4XX_COUNT, EcsMetric.HTTP_CODE_TARGET_5XX_COUNT, EcsMetric.REQUEST_COUNT_PER_TARGET,
+      EcsMetric.TARGET_PROCESSED_BYTES, EcsMetric.TARGET_RESPONSE_TIME].some((ecsMetric: EcsMetric) => ecsMetric.customValue === this.customValue);
+  }
 }
 
 /**
@@ -804,10 +861,10 @@ export abstract class BaseService extends Resource
   */
   public createEcsMetricAlarm(metric: EcsMetric, ecsMetricAlarmProps?: EcsMetricAlarmProps): cloudwatch.Alarm {
     // Throw an error if service connect is not configured
-    if (isServiceConnectMetric(metric) && !this._serviceConnectConfig) {
+    if (metric.isServiceConnectMetric() && !this._serviceConnectConfig) {
       throw new Error('Service connect must be enabled to set service connect metric alarms.');
     }
-    const ecsMetric = this.metric(metric, ecsMetricAlarmProps?.metricProps);
+    const ecsMetric = this.metric(metric.customValue, ecsMetricAlarmProps?.metricProps);
     const alarmName = Names.uniqueId(this);
     const metricAlarm = new cloudwatch.Alarm(this, alarmName,
       ecsMetricAlarmProps?.alarmProps ? ecsMetricAlarmProps.alarmProps : {
@@ -1650,9 +1707,4 @@ function determineContainerNameAndPort(options: DetermineContainerNameAndPortOpt
   }
 
   return {};
-}
-
-function isServiceConnectMetric(metric: EcsMetric): boolean {
-  return ![EcsMetric.CPU_RESERVATION, EcsMetric.CPU_UTILIZATION, EcsMetric.MEMORY_RESERVATION,
-    EcsMetric.MEMORY_UTILIZATION, EcsMetric.GPU_RESERVATION].includes(metric);
 }

--- a/packages/@aws-cdk/aws-ecs/test/ec2/ec2-service.test.ts
+++ b/packages/@aws-cdk/aws-ecs/test/ec2/ec2-service.test.ts
@@ -1712,6 +1712,141 @@ describe('ec2 service', () => {
       });
     });
 
+    test('service connect metric alarm w/o service connect enabled', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const vpc = new ec2.Vpc(stack, 'MyVpc', {});
+      const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+      addDefaultCapacityProvider(cluster, stack, vpc);
+      const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'Ec2TaskDef');
+
+      taskDefinition.addContainer('web', {
+        image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+        memoryLimitMiB: 512,
+      });
+
+      const service = new ecs.Ec2Service(stack, 'Ec2Service', {
+        cluster,
+        taskDefinition,
+        deploymentController: {
+          type: DeploymentControllerType.ECS,
+        },
+      });
+
+      // THEN
+      expect(() => {
+        service.createEcsMetricAlarm(EcsMetric.ACTIVE_CONNECTION_COUNT);
+      }).toThrow('Service connect must be enabled to set service connect metric alarms.');
+    });
+
+    test('service connect metric alarm with service connect enabled', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const vpc = new ec2.Vpc(stack, 'MyVpc', {});
+      const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+      addDefaultCapacityProvider(cluster, stack, vpc);
+      const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'Ec2TaskDef');
+
+      taskDefinition.addContainer('web', {
+        image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+        memoryLimitMiB: 512,
+        portMappings: [
+          {
+            containerPort: 80,
+            name: 'api',
+          },
+        ],
+      });
+      cluster.addDefaultCloudMapNamespace({
+        name: 'cool',
+      });
+
+      const service = new ecs.Ec2Service(stack, 'Ec2Service', {
+        cluster,
+        taskDefinition,
+        deploymentController: {
+          type: DeploymentControllerType.ECS,
+        },
+      });
+      service.enableServiceConnect({
+        services: [
+          {
+            portMappingName: 'api',
+          },
+        ],
+      });
+      const alarm = service.createEcsMetricAlarm(EcsMetric.ACTIVE_CONNECTION_COUNT, { useAsDeploymentAlarm: true });
+
+      // THEN
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::ECS::Service', {
+        DeploymentConfiguration: {
+          Alarms: {
+            Enable: true,
+            Rollback: true,
+            AlarmNames: [alarm.node.id],
+          },
+        },
+      });
+    });
+
+    test('service connect metric alarm with service connect enabled and useAsDeploymentAlarm disabled', () => {
+      // GIVEN
+      const stack = new cdk.Stack();
+      const vpc = new ec2.Vpc(stack, 'MyVpc', {});
+      const cluster = new ecs.Cluster(stack, 'EcsCluster', { vpc });
+      addDefaultCapacityProvider(cluster, stack, vpc);
+      const taskDefinition = new ecs.Ec2TaskDefinition(stack, 'Ec2TaskDef');
+      const myAlarm = cloudwatch.Alarm.fromAlarmArn(stack, 'myAlarm', 'arn:aws:cloudwatch:us-east-1:1234567890:alarm:alarm1');
+
+      taskDefinition.addContainer('web', {
+        image: ecs.ContainerImage.fromRegistry('amazon/amazon-ecs-sample'),
+        memoryLimitMiB: 512,
+        portMappings: [
+          {
+            containerPort: 80,
+            name: 'api',
+          },
+        ],
+      });
+      cluster.addDefaultCloudMapNamespace({
+        name: 'cool',
+      });
+
+      const service = new ecs.Ec2Service(stack, 'Ec2Service', {
+        cluster,
+        taskDefinition,
+        deploymentController: {
+          type: DeploymentControllerType.ECS,
+        },
+      });
+      service.enableServiceConnect({
+        services: [
+          {
+            portMappingName: 'api',
+          },
+        ],
+      });
+
+      service.enableDeploymentAlarms({
+        alarms: [myAlarm],
+        behavior: AlarmBehavior.FAIL_ON_ALARM,
+      });
+      service.createEcsMetricAlarm(EcsMetric.ACTIVE_CONNECTION_COUNT);
+
+      // THEN
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::ECS::Service', {
+        DeploymentConfiguration: {
+          Alarms: {
+            Enable: true,
+            Rollback: false,
+            AlarmNames: [myAlarm.alarmName],
+          },
+        },
+      });
+    });
+
     test('disassociate alarm config', () => {
       // GIVEN
       const stack = new cdk.Stack();


### PR DESCRIPTION
> Chore: serviceConnect Metric in Alarm Based Rollback
>Adding all available metrics where this metrics are only available if you have configured Amazon ECS Service Connect. Also added validation like service connect metric alarms cannot be set when a service has not enabled service connect. 
<img width="773" alt="image" src="https://user-images.githubusercontent.com/115483524/226687075-714a7cea-1fb5-4a32-8e3f-b4b07484afc7.png">

>
> Describe the reason for this change, what the solution is, and any
> important design decisions you made. 
>
> Remember to follow the [CONTRIBUTING GUIDE] and [DESIGN GUIDELINES] for any
> code you submit.
>
> [CONTRIBUTING GUIDE]: https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md
> [DESIGN GUIDELINES]: https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md

Closes #<issue number here>.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
